### PR TITLE
Release 1.1.5 — Moved @aws-sdk/s3-request-presigner to dependenciesRelease 1.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shubhvora/boto3-js",
-  "version": "1.1.2",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shubhvora/boto3-js",
-      "version": "1.1.2",
+      "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.908.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shubhvora/boto3-js",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Python boto3-style wrapper for AWS SDK v3",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
- Moved @aws-sdk/s3-request-presigner from devDependencies → dependencies
- Ensures the SDK is available at runtime for S3 pre-signed URL generation
- Patch release (no breaking changes)