### PR TITLE
Release 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shubhvora/boto3-js",
-  "version": "1.1.6",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shubhvora/boto3-js",
-      "version": "1.1.6",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.908.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shubhvora/boto3-js",
-  "version": "1.1.6",
+  "version": "2.0.0",
   "description": "Python boto3-style wrapper for AWS SDK v3",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
chore(release): bump version to 2.0.0 (breaking changes - new AWSService enum and camelCase methods)